### PR TITLE
Relaymail additional options

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Role Variables
 
 **Note:**  Options set using `relaymail_additional_options` will override previous settings.
 Per the postfix manual, _"When the same parameter is defined multiple times, only the last instance is remembered."_
-So while overrides are valid, postfix will generate a warning message.
+So while overrides are valid, postfix will generate a warning message
 
 Example Playbook
 ----------------
@@ -67,7 +67,7 @@ Example Playbook
           relaymail_overwrite_to: local
           relaymail_overwrite_to_target: user2@example.org
           relaymail_additional_options:
-            smtp_tls_wrappermode: yes
+            smtp_tls_wrappermode: "yes"
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -48,7 +48,12 @@ Role Variables
     * Default: `all`
 * `relaymail_overwrite_to_target`: email address which mails with overwritten to should be sent to (required when `relaymail_overwrite_to` is not `none`)
     * Example: `user2@example.org`
+* `relaymail_additional_options`: dictionary of key/value pairs to append to main.cf.
+    * Default: {}
 
+**Note:**  Options set using `relaymail_additional_options` will override previous settings.
+Per the postfix manual, _"When the same parameter is defined multiple times, only the last instance is remembered."_
+So while overrides are valid, postfix will generate a warning message.
 
 Example Playbook
 ----------------
@@ -61,7 +66,8 @@ Example Playbook
           relaymail_smtp_password: secret
           relaymail_overwrite_to: local
           relaymail_overwrite_to_target: user2@example.org
-
+          relaymail_additional_options:
+            smtp_tls_wrappermode: yes
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,8 +3,11 @@ relaymail_force_from_address: true
 
 # "all" overwrites the to addresses for all users
 # "local" overwrites the to address for emails addressed to local users
-# "none" 
+# "none"
 relaymail_overwrite_to: all
 
 # Set relay SMTP port to 25 by default
 relaymail_smtp_port: 25
+
+# Add more options at end of main.cf
+relaymail_additional_options: {}

--- a/templates/main.cf
+++ b/templates/main.cf
@@ -42,7 +42,7 @@ alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
 
 {% else %}
-mydestination = 
+mydestination =
 local_transport = error:local delivery is disabled
 # and forward them using recipient_canonical_maps
 recipient_canonical_maps = regexp:/etc/postfix/recipient_canonical_maps
@@ -51,3 +51,8 @@ recipient_canonical_classes = envelope_recipient
 # rewrite the header recipient too
 #recipient_canonical_classes = envelope_recipient, header_recipient
 {% endif %}
+
+# Options added here will override previous settings.
+{% for key, value in relaymail_additional_options.items(): %}
+{{ key }} = {{value}}
+{% endfor %}

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -9,3 +9,5 @@
       relaymail_smtp_password: secret
       relaymail_overwrite_to: local
       relaymail_overwrite_to_target: user2@example.org
+      relaymail_extra_options:
+        smtp_tls_wrappermode: yes

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -10,4 +10,4 @@
       relaymail_overwrite_to: local
       relaymail_overwrite_to_target: user2@example.org
       relaymail_extra_options:
-        smtp_tls_wrappermode: yes
+        smtp_tls_wrappermode: "yes"


### PR DESCRIPTION
I propose adding a new role attribute `relaymail_additional_options` to provide a general way to add or override any additional settings you may need, appending them to the end of the `main.cf` file.

For example, my smtp server (Rackmail) requires `smtp_tls_wrappermode = yes` to be set in the main.cf file.

Since the default for this role attribute is `{}`, this will not be a breaking change.