### PR TITLE
Update Travis matrix to test against Ansible 2.3.3 + 2.4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@
 language: python
 python: "2.7"
 
+env:
+  matrix:
+    - ANSIBLE_VERSION="2.3.3"
+    - ANSIBLE_VERSION="2.4.3"
+
 addons:
   apt:
     packages:
@@ -10,7 +15,7 @@ addons:
 
 install:
   # Install ansible
-  - pip install ansible
+  - pip install ansible=="$ANSIBLE_VERSION"
 
   # Check ansible version
   - ansible --version

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,2 @@
- - import_tasks: relaymail.yml
+ - include: relaymail.yml
    tags: relaymail


### PR DESCRIPTION
This is a first pass before adding support for Ansible 2.3.3.

The 2.3.3 build will fail because `import_tasks` is new in 2.4 ([doc](https://docs.ansible.com/ansible/2.4/import_tasks_module.html)).

Inspiration: https://github.com/ANXS/postgresql/blob/master/.travis.yml