### PR TITLE
Make SASL authentication work

### DIFF
--- a/tasks/relaymail.yml
+++ b/tasks/relaymail.yml
@@ -1,8 +1,8 @@
-- name: Install package needed for SASL authentication
-  apt: name=libsasl2-modules state=present
-
-- name: Install postfix package
-  apt: name=postfix state=present
+- name: Install required packages
+  apt: name={{ item }} state=present
+  with_items:
+    - postfix
+    - libsasl2-modules
  
 - name: Add postfix config files
   template: src={{ item }} dest=/etc/postfix/ owner=root group=root mode=644

--- a/tasks/relaymail.yml
+++ b/tasks/relaymail.yml
@@ -1,3 +1,6 @@
+- name: Install package needed for SASL authentication
+  apt: name=libsasl2-modules state=present
+
 - name: Install postfix package
   apt: name=postfix state=present
  


### PR DESCRIPTION
SASL authentication is used to connect to Gmail for example.

On my Ubuntu server this wasn't needed, but my minimal Raspberry Pi installation did not work without this. I'm guessing it was just luck (or the heavier install) that it was installed on Ubuntu already.