### PR TITLE
Centos 7 support

### DIFF
--- a/tasks/relaymail.yml
+++ b/tasks/relaymail.yml
@@ -1,9 +1,11 @@
+- name: Import OS family specific vars
+  include_vars: "vars/{{ ansible_os_family.lower() }}.yml"
+
 - name: Install required packages
-  apt: name={{ item }} state=present
-  with_items:
-    - postfix
-    - libsasl2-modules
- 
+  package:
+    state: present
+    name: "{{ relaymail_packages }}"
+
 - name: Add postfix config files
   template: src={{ item }} dest=/etc/postfix/ owner=root group=root mode=644
   with_items:

--- a/tasks/relaymail.yml
+++ b/tasks/relaymail.yml
@@ -10,7 +10,6 @@
   template: src={{ item }} dest=/etc/postfix/ owner=root group=root mode=644
   with_items:
     - main.cf
-    - master.cf
     - recipient_canonical_maps
     - sender_canonical_maps
   notify: restart postfix

--- a/templates/main.cf
+++ b/templates/main.cf
@@ -53,6 +53,6 @@ recipient_canonical_classes = envelope_recipient
 {% endif %}
 
 # Options added here will override previous settings.
-{% for key, value in relaymail_additional_options.items(): %}
+{% for key, value in relaymail_additional_options.items() %}
 {{ key }} = {{value}}
 {% endfor %}

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,4 +1,5 @@
 relaymail_packages:
   - postfix
   - libsasl2-modules
+  - ca-certificates
 

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,0 +1,4 @@
+relaymail_packages:
+  - postfix
+  - libsasl2-modules
+

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -2,6 +2,7 @@ relaymail_packages:
   - postfix
   - cyrus-sasl
   - cyrus-sasl-plain
+  - ca-certificates
 
 relaymail_additional_options:
   smtp_tls_CAfile: /etc/ssl/certs/ca-bundle.trust.crt

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,0 +1,8 @@
+relaymail_packages:
+  - postfix
+  - cyrus-sasl
+  - cyrus-sasl-plain
+
+relaymail_additional_options:
+  smtp_tls_CAfile: /etc/ssl/certs/ca-bundle.trust.crt
+


### PR DESCRIPTION
This pull request adds basic support for different os family.

As there are different `master.cf` config files shipped (due to different postfix versions) in `Debian` and `Centos` and the file currently has no customisation it is removed from the deployed templates.